### PR TITLE
Initial fixes for partition problem

### DIFF
--- a/vis_services/lib/author_network.py
+++ b/vis_services/lib/author_network.py
@@ -225,7 +225,7 @@ def get_network_with_groups(authors_lists, data):
     to_use_links = {}
     for couple in chosen_links:
         #I round the weight to the integer after multiplying it to 100
-        value_link = int(round(chosen_links[couple] * 100))
+        value_link = math.floor(chosen_links[couple] * 100+.5)
         to_use_links[couple] = value_link
 
     #I group the links with the same weight
@@ -302,7 +302,7 @@ def get_network_with_groups(authors_lists, data):
     to_use_nodes = _remap_dict_in_range(to_use_nodes, [5, 150])
 
     #I extract the list of names in a list, because I need the positions
-    listnames = list(to_use_nodes.keys())
+    listnames = sorted(to_use_nodes.keys())
     #then I build the final variables
     nodes = []
     for name in listnames:


### PR DESCRIPTION
This fixes the problem with the surprising results of the `round()` function in Python 3.8 versus Python 2.7. E.g. `round(12.5)` evaluates to `12` in the Python 3.8 version, while it evaluates to `13` in the Python 2.7 version. This causes different data going into the `augment_graph_data` function. With the implemented fix, the data remains the same in both versions up to the point where the network is partitioned. With the current fix, results are still different after the partitioning at https://github.com/adsabs/vis-services/blob/master/vis_services/lib/paper_network.py#L95. No idea how to fix this. 